### PR TITLE
docs: `latest` is not valid commit reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can use goqumysqllint via [golangci-lint's module plugin system](https://gol
 In .custom-gcl.yml:
 
 ```yaml
-version: latest
+version: v1.62.2 # or specify 'master' to always build latest but maybe unstable version
 plugins:
   - module: 'github.com/utgwkk/goqumysqllint'
     version: latest


### PR DESCRIPTION
The root `version` field is for the commit reference of https://github.com/golangci/golangci-lint.

If you specify `latest`, golangci-lint tends to clone `latest` branch but it does not exist.

So this field must be a valid commit reference (branches, tags, or so on).